### PR TITLE
fix(image-compression-lib): resolve typescript build errors

### DIFF
--- a/image-compression-lib/tsconfig.node.json
+++ b/image-compression-lib/tsconfig.node.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "node",
     "outDir": "./dist/node",


### PR DESCRIPTION
The `npm run build` command in `image-compression-lib` was failing with TypeScript errors related to missing DOM types (e.g., HTMLCanvasElement, Worker, MessageEvent).

This was caused by the `tsconfig.node.json` file, which was overriding the `compilerOptions.lib` from the base `tsconfig.json` and removing the "DOM" and "DOM.Iterable" entries.

This change adds "DOM" and "DOM.Iterable" back to the `lib` array in `tsconfig.node.json`. This makes the DOM types available to the TypeScript compiler during the Node.js build, which is necessary because some source files are shared between the browser and Node.js environments and require these types to be present at compile time.